### PR TITLE
fix-abifm-water-saturation

### DIFF
--- a/notebooks/setup/aerosol-inp-closure.ipynb
+++ b/notebooks/setup/aerosol-inp-closure.ipynb
@@ -46,11 +46,11 @@
    "source": [
     "**Figure 1: COMBLE observed INP vs. predicted INP on March 13.** Predicted INP number concentrations (y-axis) are compared to observed INP number concentrations (x-axis) at the COMBLE site (18 UTC, March 13). Each colored symbol represents a predicted INP value at a given temperature (colorbar, °C). The five IMF parameterizations are: ABIFM (circles; CNT-based, Knopf and Alpert, 2013; Alpert et al., 2022), A2022 (squares; singular INAS, Alpert et al., 2022), M2018 (triangles; singular INAS, McCluskey et al., 2018), Fletcher (diamonds; empirical, Fletcher, 1962), and Cooper (five-pointed stars; empirical, Cooper, 1986). Black symbols with error bars denote observed INP concentrations. The 1:1 line (solid black) indicates perfect closure.\n",
     "\n",
-    "<img src=\"https://github.com/yijias33/COMBLEZeppelinfigures/blob/main/COMBLE_FINAL.png?raw=true\">\n",
+    "<img src=\"https://github.com/yijias33/COMBLEZeppelinfigures/blob/main/comble_aerosol_inp_closure_aw1.png?raw=true\">\n",
     "\n",
     "**Figure 2: Zeppelin observed INP vs. predicted INP on March 13.** Same as Figure 1, but for the Zeppelin observatory (0 UTC, March 13), which is located upwind of the cold-air outbreak.\n",
     "\n",
-    "<img src=\"https://github.com/yijias33/COMBLEZeppelinfigures/blob/main/ZEPPELIN_FINAL.png?raw=true\">"
+    "<img src=\"https://github.com/yijias33/COMBLEZeppelinfigures/blob/main/zeppelin_aerosol_inp_closure_aw1.png?raw=true\">"
    ]
   },
   {
@@ -139,7 +139,7 @@
    "metadata": {},
    "source": [
     "## Calculate the predicted INPs\n",
-    "For the time-dependent IMF parameterization (ABIFM) an ice nucleation activation time, based on the INP measurements has to be applied. The chosen activation time is 1 min following the recommendation given in <a href=\"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9629709/\"> Alpert et al., (2022)</a>. The implemented equations for selected SSA IMF parameterizations can be found in the file <a href=\"https://drive.google.com/file/d/1c0-iEJtbTOWg8Vl7_G_Iu51-8suH6vbN/view?usp=sharing\"> AER.py</a>. "
+    "For the time-dependent IMF parameterization (ABIFM), we follow <a href=\"https://doi.org/10.1126/sciadv.abq6842\">Alpert et al. (2022)</a>, who used an activation time of 1 min to approximate the nucleation timescales of the contributing experiments. ABIFM is evaluated at water saturation ($a_w=1.0$). The implemented AL2022 INAS fit likewise represents pure-water droplets ($a_w=1.0$)."
    ]
   },
   {
@@ -160,18 +160,18 @@
     "\n",
     "for T in range(1, 48, 1):\n",
     "        #COMBLE18UTCMarch13case\n",
-    "        COMBLEAL2022 = quickcalc(aer_info_dict={**aer_info1, **{\"singular_fun\": \"AL2022\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False,RH_in=99.5)\n",
+    "        COMBLEAL2022 = quickcalc(aer_info_dict={**aer_info1, **{\"singular_fun\": \"AL2022\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False)\n",
     "        COMBLEAL2022INP.append(COMBLEAL2022.variables['inp_tot'].values)\n",
-    "        COMBLEMC2018 = quickcalc(aer_info_dict={**aer_info1, **{\"singular_fun\": \"MC2018\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False,RH_in=99.5)\n",
+    "        COMBLEMC2018 = quickcalc(aer_info_dict={**aer_info1, **{\"singular_fun\": \"MC2018\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False)\n",
     "        COMBLEMC2018INP.append(COMBLEMC2018.variables['inp_tot'].values)\n",
-    "        COMBLEABIFM =quickcalc(aer_info_dict=aer_info1, T_in=243+(T-1)*0.5, use_ABIFM=True,RH_in=99.5, ABIFM_delta_t=60.)\n",
+    "        COMBLEABIFM =quickcalc(aer_info_dict=aer_info1, T_in=243+(T-1)*0.5, use_ABIFM=True,RH_in=100.0, ABIFM_delta_t=60.)\n",
     "        COMBLEABIFMINP.append(COMBLEABIFM.variables['inp_tot'].values)\n",
     "        #ZEPPELIN0UTCMarch13case\n",
-    "        ZeppelinAL2022 = quickcalc(aer_info_dict={**aer_info2, **{\"singular_fun\": \"AL2022\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False,RH_in=99.5)\n",
+    "        ZeppelinAL2022 = quickcalc(aer_info_dict={**aer_info2, **{\"singular_fun\": \"AL2022\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False)\n",
     "        ZeppelinAL2022INP.append(ZeppelinAL2022.variables['inp_tot'].values)\n",
-    "        ZeppelinMC2018 = quickcalc(aer_info_dict={**aer_info2, **{\"singular_fun\": \"MC2018\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False,RH_in=99.5)\n",
+    "        ZeppelinMC2018 = quickcalc(aer_info_dict={**aer_info2, **{\"singular_fun\": \"MC2018\"}}, T_in=243+(T-1)*0.5, use_ABIFM=False)\n",
     "        ZeppelinMC2018INP.append(ZeppelinMC2018.variables['inp_tot'].values)\n",
-    "        ZeppelinABIFM =quickcalc(aer_info_dict=aer_info2, T_in=243+(T-1)*0.5, use_ABIFM=True,RH_in=99.5, ABIFM_delta_t=60.)\n",
+    "        ZeppelinABIFM =quickcalc(aer_info_dict=aer_info2, T_in=243+(T-1)*0.5, use_ABIFM=True,RH_in=100.0, ABIFM_delta_t=60.)\n",
     "        ZeppelinABIFMINP.append(ZeppelinABIFM.variables['inp_tot'].values)"
    ]
   },


### PR DESCRIPTION
Evaluate ABIFM at water saturation (RH_in=100%, (a_w=1.0)) instead of 99.5% RH. Remove unnecessary RH_in arguments from the AL2022 and M2018 calculations. Update the linked COMBLE and Zeppelin closure figures and supporting result files. The correction increases the ABIFM predictions, but the main conclusions remain unchanged.